### PR TITLE
BUG use semicolon for databases for the line magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed an issue where databases with spaces in their names could not be used
-  the line magic splits on spaces. It now splits on semicolons.
+  the line magic splits on spaces. It now splits on semicolons. (#8)
 
 ## [0.1.2] - 2017-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Fixed an issue where databases with spaces in their names could not be used
+  the line magic splits on spaces. It now splits on semicolons.
+
 ## [0.1.2] - 2017-09-20
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -43,4 +43,4 @@ To get a table preview, use the cell magic like this::
 
 To return a DataFrame for further processing, use the line magic like this::
 
-    df = %civisquery my-database select * from dummy.table;
+    df = %civisquery my-database; select * from dummy.table;

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -15,7 +15,7 @@ def magic(line, cell=None):
 
     if cell is None:
         # Not using maxsplit kwarg b/c it is not compatible w/ Python 2
-        items = line.split(';', 1)
+        items = [s for s in line.split(';', 1) if len(s) > 0]
         # allow spaces
         if len(items) == 1:
             database, sql = items[0].split(' ', 1)

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -15,7 +15,7 @@ def magic(line, cell=None):
 
     if cell is None:
         # Not using maxsplit kwarg b/c it is not compatible w/ Python 2
-        database, sql = line.split(' ', 1)
+        database, sql = line.split(';', 1)
         df = civis.io.read_civis_sql(
             sql, database.strip(), use_pandas=True, client=client)
         if len(df) == 0:

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -15,9 +15,14 @@ def magic(line, cell=None):
 
     if cell is None:
         # Not using maxsplit kwarg b/c it is not compatible w/ Python 2
-        database, sql = line.split(';', 1)
+        items = line.split(';', 1)
+        # allow spaces
+        if len(items) == 1:
+            database, sql = items[0].split(' ', 1)
+        else:
+            database, sql = items
         df = civis.io.read_civis_sql(
-            sql, database.strip(), use_pandas=True, client=client)
+            sql.strip(), database.strip(), use_pandas=True, client=client)
         if len(df) == 0:
             df = None
     else:

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -39,7 +39,7 @@ def test_cell_magic(civis_mock, rows):
 def test_line_magic(civis_mock, cols):
     sql = 'select * from dummy.table'
     database = 'my-database'
-    line = ' '.join([database, sql])
+    line = '; '.join([database, sql])
     test_df = pd.DataFrame({'c1': cols[0], 'c2': cols[1]})
     civis_mock.io.read_civis_sql.return_value = test_df
     civis_mock.APIClient.return_value = -1

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -39,7 +39,7 @@ def test_cell_magic(civis_mock, rows):
     [(['a', 'b'], [1, 2]), ([], [])])
 @mock.patch('civis_jupyter_ext.magics.query.civis')
 def test_line_magic(civis_mock, cols, sep):
-    sql = 'select * from dummy.table;'
+    sql = 'select * from dummy.table'
     database = 'my-database'
     line = sep.join([database, sql])
     test_df = pd.DataFrame({'c1': cols[0], 'c2': cols[1]})

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -33,13 +33,13 @@ def test_cell_magic(civis_mock, rows):
 
 
 @pytest.mark.parametrize(
-    'cols',
-    [(['a', 'b'], [1, 2]), ([], [])])
+    'cols,sep',
+    [((['a', 'b'], [1, 2]), ' '), (([], []), '; ')])
 @mock.patch('civis_jupyter_ext.magics.query.civis')
-def test_line_magic(civis_mock, cols):
+def test_line_magic(civis_mock, cols, sep):
     sql = 'select * from dummy.table'
-    database = 'my-database'
-    line = '; '.join([database, sql])
+    database = 'my-database;'
+    line = sep.join([database, sql])
     test_df = pd.DataFrame({'c1': cols[0], 'c2': cols[1]})
     civis_mock.io.read_civis_sql.return_value = test_df
     civis_mock.APIClient.return_value = -1

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -34,7 +34,7 @@ def test_cell_magic(civis_mock, rows):
 
 @pytest.mark.parametrize(
     'sep,database', [
-        (' ', 'my-database), 
+        (' ', 'my-database'),
         ('; ', 'my database'),
         ('; ', 'my-database')])
 @pytest.mark.parametrize(

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -37,8 +37,8 @@ def test_cell_magic(civis_mock, rows):
     [((['a', 'b'], [1, 2]), ' '), (([], []), '; ')])
 @mock.patch('civis_jupyter_ext.magics.query.civis')
 def test_line_magic(civis_mock, cols, sep):
-    sql = 'select * from dummy.table'
-    database = 'my-database;'
+    sql = 'select * from dummy.table;'
+    database = 'my-database'
     line = sep.join([database, sql])
     test_df = pd.DataFrame({'c1': cols[0], 'c2': cols[1]})
     civis_mock.io.read_civis_sql.return_value = test_df

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -33,14 +33,16 @@ def test_cell_magic(civis_mock, rows):
 
 
 @pytest.mark.parametrize(
-    'sep', [' ', '; '])
+    'sep,database', [
+        (' ', 'my-database), 
+        ('; ', 'my database'),
+        ('; ', 'my-database')])
 @pytest.mark.parametrize(
     'cols',
     [(['a', 'b'], [1, 2]), ([], [])])
 @mock.patch('civis_jupyter_ext.magics.query.civis')
-def test_line_magic(civis_mock, cols, sep):
+def test_line_magic(civis_mock, cols, sep, database):
     sql = 'select * from dummy.table'
-    database = 'my-database'
     line = sep.join([database, sql])
     test_df = pd.DataFrame({'c1': cols[0], 'c2': cols[1]})
     civis_mock.io.read_civis_sql.return_value = test_df

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -33,8 +33,10 @@ def test_cell_magic(civis_mock, rows):
 
 
 @pytest.mark.parametrize(
-    'cols,sep',
-    [((['a', 'b'], [1, 2]), ' '), (([], []), '; ')])
+    'sep', [' ', '; '])
+@pytest.mark.parametrize(
+    'cols',
+    [(['a', 'b'], [1, 2]), ([], [])])
 @mock.patch('civis_jupyter_ext.magics.query.civis')
 def test_line_magic(civis_mock, cols, sep):
     sql = 'select * from dummy.table;'


### PR DESCRIPTION
This PR uses a semicolon to split the database for the line magic.

Spaces are still supported for backwards compatibility.