### PR TITLE
Support delimited database names in magic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ notifications:
 language: python
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Drop support for Python 3.4
+- Update civisquery magic to support database names with spaces
+- Better document civisquery magic
+
 ## [0.1.3] - 2017-11-28
 
 ### Fixed

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -12,7 +12,7 @@ def magic(line, cell=None):
 
     Examples
     --------
-    >>> %%civisquery
+    >>> %%civisquery DATABASE
     ... SELECT * FROM schema.table;
 
     >>> %civisquery DATABASE QUERY

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -21,12 +21,28 @@ def magic(line, cell=None):
             database, sql = items[0].split(' ', 1)
         else:
             database, sql = items
+
+        try:
+            # if it's an integer, read_civis_sql will let it pass through
+            # if it's a string, it tries to look up a database name
+            # it's helpful to pass an int when you use the line magic
+            # but your database name has a space in it
+            database = int(database.strip())
+        except ValueError:
+            database = database.strip()
+
         df = civis.io.read_civis_sql(
-            sql.strip(), database.strip(), use_pandas=True, client=client)
+            sql.strip(), database, use_pandas=True, client=client)
         if len(df) == 0:
             df = None
     else:
         database = line.strip()
+
+        try:  # support database IDs like line magic
+            database = int(database)
+        except ValueError:
+            pass
+
         sql = cell
 
         fut = civis.io.query_civis(

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -10,21 +10,37 @@ def magic(line, cell=None):
     This magic works both as a cell magic (for table previews) and a
     line magic to query a table and return a DataFrame.
 
+    You can pass either a database name or an ID in the below. If your database
+    name contains a space, you must quote delimit the database.
+
+    If your version of Python supports it, F-string interpolation will work on
+    the line in both the line and cell magics but not the cell of a cell magic.
+    This isn't currently supported in IPython.
+
     Examples
     --------
+
+    Use the cell magic
+
     >>> %%civisquery DATABASE
     ... SELECT * FROM schema.table;
 
+    Use the line magic
+
     >>> %civisquery DATABASE QUERY
 
-    The latter can be useful if you want to use f-strings for variables
-    defined in another cell.
+    Use f-strings with the line magic
 
     >>> %civisquery {DATABASE_ID} {SQL_STATEMENT}
 
-    Note that you can pass a database name or a database ID. If using the
-    line magic, your database name can't contain spaces, so you must use
-    a database ID.
+    Use f-strings with the cell magic
+
+    >>> %%civisquery {DATABASE}
+    SELECT * FROM schema.table;
+
+    Query a database name with spaces
+
+    >>> %civisquery : "My Database" {SQL_STATEMENT}
     """
 
     client = civis.APIClient()

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -9,6 +9,22 @@ def magic(line, cell=None):
 
     This magic works both as a cell magic (for table previews) and a
     line magic to query a table and return a DataFrame.
+
+    Examples
+    --------
+    >>> %%civisquery
+    ... SELECT * FROM schema.table;
+
+    >>> %civisquery DATABASE QUERY
+
+    The latter can be useful if you want to use f-strings for variables
+    defined in another cell.
+
+    >>> %civisquery {DATABASE_ID} {SQL_STATEMENT}
+
+    Note that you can pass a database name or a database ID. If using the
+    line magic, your database name can't contain spaces, so you must use
+    a database ID.
     """
 
     client = civis.APIClient()

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -1,3 +1,5 @@
+import csv
+
 import pandas as pd
 import civis
 
@@ -46,14 +48,14 @@ def magic(line, cell=None):
     client = civis.APIClient()
 
     if cell is None:
-        # Not using maxsplit kwarg b/c it is not compatible w/ Python 2
-        items = [s for s in line.split(';', 1) if len(s) > 0]
-        # allow spaces
-        if len(items) == 1:
-            database, sql = items[0].split(' ', 1)
-        else:
-            database, sql = items
-
+        database, *lines = next(csv.reader(
+            [line],
+            delimiter=" ",
+            quotechar='"',
+            doublequote=True,
+            skipinitialspace=True)
+        )
+        sql = " ".join(lines)
         try:
             # if it's an integer, read_civis_sql will let it pass through
             # if it's a string, it tries to look up a database name

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -13,7 +13,8 @@ def magic(line, cell=None):
     line magic to query a table and return a DataFrame.
 
     You can pass either a database name or an ID in the below. If your database
-    name contains a space, you must quote delimit the database.
+    name contains a space and you are using the line magic, you must quote
+    delimit the database.
 
     If your version of Python supports it, F-string interpolation will work on
     the line in both the line and cell magics but not the cell of a cell magic.
@@ -42,7 +43,12 @@ def magic(line, cell=None):
 
     Query a database name with spaces
 
-    >>> %civisquery : "My Database" {SQL_STATEMENT}
+    >>> %civisquery "My Database" {SQL_STATEMENT}
+
+    Cell magic for a database with a space
+
+    >>> %%civisquery My Database
+    SELECT * FROM schema.table
     """
 
     client = civis.APIClient()
@@ -58,9 +64,9 @@ def magic(line, cell=None):
         sql = " ".join(lines)
         try:
             # if it's an integer, read_civis_sql will let it pass through
-            # if it's a string, it tries to look up a database name
-            # it's helpful to pass an int when you use the line magic
-            # but your database name has a space in it
+            # but if you pass an integer to the magic it gets coerced to
+            # a string. it will try to look up an integer string as a
+            # database name and will fail to find that name
             database = int(database.strip())
         except ValueError:
             database = database.strip()

--- a/civis_jupyter_ext/magics/query.py
+++ b/civis_jupyter_ext/magics/query.py
@@ -54,13 +54,16 @@ def magic(line, cell=None):
     client = civis.APIClient()
 
     if cell is None:
-        database, *lines = next(csv.reader(
+        reader = csv.reader(
             [line],
             delimiter=" ",
             quotechar='"',
             doublequote=True,
             skipinitialspace=True)
-        )
+        parsed_line = next(reader)
+
+        database, lines = parsed_line[0], parsed_line[1:]
+
         sql = " ".join(lines)
         try:
             # if it's an integer, read_civis_sql will let it pass through

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -36,9 +36,7 @@ def test_cell_magic(civis_mock, rows):
     'sep,database', [
         (' ', '\"My Database\"'),
         (' ', 'my-database'),
-        (' ', '123'),
-        ('; ', 'my database'),
-        ('; ', 'my-database')])
+        (' ', '123')])
 @pytest.mark.parametrize(
     'cols',
     [(['a', 'b'], [1, 2]), ([], [])])
@@ -60,6 +58,7 @@ def test_line_magic(civis_mock, cols, sep, database):
     try:
         database = int(database)
     except ValueError:
-        pass
+        # if present the parser will strip the delimiter, so remove it here
+        database = database.strip('"')
     civis_mock.io.read_civis_sql.assert_called_with(
         sql, database, use_pandas=True, client=-1)

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -34,6 +34,7 @@ def test_cell_magic(civis_mock, rows):
 
 @pytest.mark.parametrize(
     'sep,database', [
+        (' ', '\"My Database\"'),
         (' ', 'my-database'),
         (' ', '123'),
         ('; ', 'my database'),

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -35,6 +35,7 @@ def test_cell_magic(civis_mock, rows):
 @pytest.mark.parametrize(
     'sep,database', [
         (' ', 'my-database'),
+        (' ', '123'),
         ('; ', 'my database'),
         ('; ', 'my-database')])
 @pytest.mark.parametrize(
@@ -53,5 +54,11 @@ def test_line_magic(civis_mock, cols, sep, database):
         assert df.equals(test_df), "Returned data is wrong!"
     else:
         assert df is None, "Returned data is wrong!"
+
+    # the function should coerce integer to integer, so check that here
+    try:
+        database = int(database)
+    except ValueError:
+        pass
     civis_mock.io.read_civis_sql.assert_called_with(
         sql, database, use_pandas=True, client=-1)


### PR DESCRIPTION
This code does two things. It allows passing of a database as an ID and it allows quote-delimited databases, so you can have spaces in a database name.

It removes the (undocumented) ability to separate a database name and the query with a semi-colon.