### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ notifications:
     email: false
 language: python
 python:
-    - "2.7"
     - "3.5"
     - "3.6"
     - "3.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- Drop support for Python 3.4
+- Drop support for Python 2.7 and 3.4
 - Update civisquery magic to support database names with spaces
 - Better document civisquery magic
 

--- a/civis_jupyter_ext/magics/tests/test_query.py
+++ b/civis_jupyter_ext/magics/tests/test_query.py
@@ -1,13 +1,8 @@
 import pytest
 import pandas as pd
-import six
+from unittest import mock
 
 from ..query import magic
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
 
 
 @pytest.mark.parametrize(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 pytest~=3.2
 flake8~=3.0
-mock~=2.0 ; python_version >= '2.7' and python_version < '3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ipython>=5.4,<=6.2.99
 pandas~=0.20
 civis~=1.6
-six~=1.10


### PR DESCRIPTION
Support for Python 2 in the Civis Python client was dropped a while ago (civisanalytics/civis-python#378), so new builds of this package no longer work in Python 2.7.  Let's drop support for Python 2 here as well, and remove the compatibility code.